### PR TITLE
Restore testing bot

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -318,7 +318,16 @@ RUN cd /tmp \
 # TestingBot Tunneling #
 # -----------------------#
 # https://testingbot.com/support/other/tunnel
-
+ENV TB_TUNNEL_URL="https://testingbot.com/tunnel/testingbot-tunnel.jar"
+# If you need to disable testingBot at build time set a build arg of testingBotEnabled=false
+ARG testingBotEnabled=true
+RUN if [ "${testingBotEnabled}" = "true" ]; then \
+  cd /tmp \
+  && wget -nv "${TB_TUNNEL_URL}" \
+  && mv testingbot-tunnel.jar /usr/local/bin \
+  && java -jar /usr/local/bin/testingbot-tunnel.jar --version; \
+  else echo "Testing Bot Disabled"; \
+  fi
 
 #===================================================
 # Run the following commands as non-privileged user


### PR DESCRIPTION
* Also make it possible to disable testing bot via a buildArg, this is
to allow builds on sites where testing bot is blocked due to
organisational Internet policies.